### PR TITLE
Compatibility with Wagtail 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ from wagtail_icons.edit_handlers import IconsChooserPanel
 from wagtail_icons.fields import IconsField
 from wagtail_icons.blocks import IconsChooserBlock
 
-from wagtail.admin.edit_handlers import StreamFieldPanel
 try:
+    from wagtail.admin.panels import StreamFieldPanel
     from wagtail.fields import StreamField
     from wagtail.models import Page
     from wagtail import blocks
 except ImportError:
     # wagtail version under 3.0
+    from wagtail.admin.edit_handlers import StreamFieldPanel
     from wagtail.core.fields import StreamField
     from wagtail.core import blocks
     from wagtail.core.models import Page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ requires = [
     "wheel",
     "wagtail>=2.15.5",
     "django",
-    "wagtail-generic-chooser',
+    "wagtail-generic-chooser",
 ]
 build-backend = "setuptools.build_meta"

--- a/tests/test_group_view.py
+++ b/tests/test_group_view.py
@@ -1,5 +1,8 @@
 # from django.test import TestCase
-from wagtail.tests.utils import WagtailTestUtils
+try:
+    from wagtail.test.utils import WagtailTestUtils
+except ImportError:
+    from wagtail.tests.utils import WagtailTestUtils
 from django.test import TestCase
 from django.test import Client
 from django.contrib.auth.models import User

--- a/tests/test_icon_views.py
+++ b/tests/test_icon_views.py
@@ -1,5 +1,8 @@
 # from django.test import TestCase
-from wagtail.tests.utils import WagtailTestUtils
+try:
+    from wagtail.test.utils import WagtailTestUtils
+except ImportError:
+    from wagtail.tests.utils import WagtailTestUtils
 from django.test import TestCase
 from django.test import Client
 from django.contrib.auth.models import User

--- a/wagtail_icons/edit_handlers.py
+++ b/wagtail_icons/edit_handlers.py
@@ -1,5 +1,8 @@
 from .widgets import AdminIconChooser
-from wagtail.admin.edit_handlers import FieldPanel
+try:
+    from wagtail.admin.panels import FieldPanel
+except ImportError:
+    from wagtail.admin.edit_handlers import FieldPanel
 
 class IconsChooserPanel(FieldPanel):
     def __init__(self, field_name, group=None, *args, **kwargs):

--- a/wagtail_icons/models/group.py
+++ b/wagtail_icons/models/group.py
@@ -1,6 +1,6 @@
 from django.db import models
 try:
-    from wagtail.utils import string_to_ascii
+    from wagtail.coreutils import string_to_ascii
 except ImportError:
     from wagtail.core.utils import string_to_ascii
 from django.utils.translation import gettext_lazy as _

--- a/wagtail_icons/models/upload.py
+++ b/wagtail_icons/models/upload.py
@@ -1,7 +1,7 @@
 import os
 from django.db import models
 try:
-    from wagtail.utils import string_to_ascii
+    from wagtail.coreutils import string_to_ascii
 except ImportError:
     from wagtail.core.utils import string_to_ascii
 from wagtail.images.models import get_upload_to


### PR DESCRIPTION
Since Wagtail 3.0:
- `wagtail.admin.edit_handlers` became `wagtail.admin.panels`
- `wagtail.tests.utils` became `wagtail.test.utils`
- `wagtail.core.utils` became `wagtail.coreutils` (and not `wagtail.utils`)

Wagtail 5.0 removed these namespaces and loading this library makes the app crash.
This PR fixes it.